### PR TITLE
Fix ABI tuple/array parsing and address encoding

### DIFF
--- a/Sources/TronWebSwift/TronABI/TronABIDecoding.swift
+++ b/Sources/TronWebSwift/TronABI/TronABIDecoding.swift
@@ -166,9 +166,13 @@ extension TronABIDecoder {
             var consumed:UInt64 = 0
             for i in 0 ..< subTypes.count {
                 let (v, c) = decodeSignleType(type: subTypes[i], data: elementItself, pointer: consumed)
-                guard let valueUnwrapped = v, let consumedUnwrapped = c else {return (nil, nil)}
+                guard let valueUnwrapped = v, let consumedUnwrapped = c else { return (nil, nil) }
                 toReturn.append(valueUnwrapped)
-                consumed = consumed + consumedUnwrapped
+                if subTypes[i].isStatic {
+                    consumed = consumed + consumedUnwrapped
+                } else {
+                    consumed = consumed + 32  // 动态类型在 head 区只占 32 字节
+                }
             }
             //            print("Tuple element is: \n" + String(describing: toReturn))
             if type.isStatic {

--- a/Sources/TronWebSwift/TronABI/TronABIEncoding.swift
+++ b/Sources/TronWebSwift/TronABI/TronABIEncoding.swift
@@ -197,14 +197,17 @@ extension TronABIEncoder {
             }
         case .address:
             if let string = value as? String {
-                guard let address = TronAddress(string) else {return nil}
-                let data = address.data
-                return data.setLengthLeft(32)
+                guard let address = TronAddress(string) else { return nil }
+                // TronAddress.data 是 21 字节（含 0x41 前缀），ABI 编码只需要后 20 字节
+                let data = address.data.count == 21 ? address.data.dropFirst(1) : address.data
+                return Data(data).setLengthLeft(32)
             } else if let address = value as? TronAddress {
-                let data = address.data
-                return data.setLengthLeft(32)
+                let data = address.data.count == 21 ? address.data.dropFirst(1) : address.data
+                return Data(data).setLengthLeft(32)
             } else if let data = value as? Data {
-                return data.setLengthLeft(32)
+                // 如果传入的 Data 也带了 0x41 前缀，同样处理
+                let cleanData = (data.count == 21 && data[0] == 0x41) ? data.dropFirst(1) : data
+                return Data(cleanData).setLengthLeft(32)
             }
         case .bool:
             if let bool = value as? Bool {

--- a/Sources/TronWebSwift/TronABI/TronABIParameterTypes.swift
+++ b/Sources/TronWebSwift/TronABI/TronABIParameterTypes.swift
@@ -220,7 +220,7 @@ extension TronABI.Element.ParameterType: TronABIEncoding {
         case .tuple(types: let types):
             let typesRepresentation = types.map({return $0.abiRepresentation})
             let typesJoined = typesRepresentation.joined(separator: ",")
-            return "tuple(\(typesJoined))"
+            return "(\(typesJoined))"
         case .string:
             return "string"
         }

--- a/Sources/TronWebSwift/TronABI/TronABIParsing.swift
+++ b/Sources/TronWebSwift/TronABI/TronABIParsing.swift
@@ -123,7 +123,7 @@ fileprivate func parseEvent(abiRecord: TronABI.Record) throws -> TronABI.Element
 
 extension TronABI.Input {
     func parse() throws -> TronABI.Element.InOut {
-        let name = self.name != nil ? self.name! : ""
+        let name = self.name ?? ""
         let parameterType = try TronABITypeParser.parseTypeString(self.type)
         if case .tuple(types: _) = parameterType {
             let components = try self.components?.compactMap({ (inp: TronABI.Input) throws -> TronABI.Element.ParameterType in
@@ -133,10 +133,38 @@ extension TronABI.Input {
             let type = TronABI.Element.ParameterType.tuple(types: components!)
             let nativeInput = TronABI.Element.InOut(name: name, type: type)
             return nativeInput
-        }
-        else {
+        } else if case .array(type: _, length: _) = parameterType {
+            // 递归处理 tuple[], tuple[][] 任意嵌套
+            let resolvedType = try resolveArrayType(parameterType, components: self.components)
+            let nativeInput = TronABI.Element.InOut(name: name, type: resolvedType)
+            return nativeInput
+        } else {
             let nativeInput = TronABI.Element.InOut(name: name, type: parameterType)
             return nativeInput
+        }
+    }
+    
+    private func resolveArrayType(_ type: TronABI.Element.ParameterType, components: [TronABI.Input]?) throws -> TronABI.Element.ParameterType {
+        switch type {
+        case .array(type: let subType, length: let length):
+            switch subType {
+            case .tuple(types: _):
+                // 最内层是 tuple，填入 components
+                let resolvedComponents = try components?.compactMap({ (inp: TronABI.Input) throws -> TronABI.Element.ParameterType in
+                    let input = try inp.parse()
+                    return input.type
+                })
+                let tupleType = TronABI.Element.ParameterType.tuple(types: resolvedComponents ?? [])
+                return TronABI.Element.ParameterType.array(type: tupleType, length: length)
+            case .array(type: _, length: _):
+                // 还有外层 array，继续递归
+                let resolvedSubType = try resolveArrayType(subType, components: components)
+                return TronABI.Element.ParameterType.array(type: resolvedSubType, length: length)
+            default:
+                return type
+            }
+        default:
+            return type
         }
     }
     


### PR DESCRIPTION
Decoding: adjust tuple decoding pointer arithmetic so dynamic members advance by 32 bytes in the head and ensure safe guard formatting (Sources/TronWebSwift/TronABI/TronABIDecoding.swift).

Encoding: handle Tron address raw bytes that include the 0x41 prefix (21 bytes) by stripping the prefix for ABI encoding; apply same logic for String, TronAddress and Data inputs (Sources/TronWebSwift/TronABI/TronABIEncoding.swift).

Parameter types: change tuple ABI representation from "tuple(a,b)" to "(a,b)" to match expected ABI syntax (Sources/TronWebSwift/TronABI/TronABIParameterTypes.swift).

Parsing: use nil-coalescing for input name default and add resolveArrayType to correctly parse arrays of tuples (including nested arrays like tuple[] or tuple[][]) by resolving components into inner tuple types (Sources/TronWebSwift/TronABI/TronABIParsing.swift).

These changes fix incorrect offsets for dynamic tuple elements, ensure addresses are encoded as 20-byte values, and add support for tuple arrays in ABI parsing.